### PR TITLE
Fix #7 - Improved comment line counting

### DIFF
--- a/function_rule.go
+++ b/function_rule.go
@@ -17,6 +17,12 @@ var loggerPattern = regexp.MustCompile("(?i)(log|logger)")
 // the method pattern also covers calls like Printf etc. as (?i)print also matches Printf.
 var loggerMethodPattern = regexp.MustCompile("(?i)(debug|info|warn|error|fatal|print|panic|trace|log)")
 
+// prefix filters for comments
+var commentPrefixFilters = []string{
+	"want `", // filter comments that are used for testing as these comments for analysistest would otherwise increase the logging density.
+	"TODO",   // filter out to-do comments
+}
+
 type FunctionFilters struct {
 	// MinLinesOfCode determines the minimum number of lines of code that a function must have to be considered.
 	MinLinesOfCode int `json:"minLinesOfCode"`
@@ -254,9 +260,7 @@ func countCommentLines(node ast.Node) int {
 			// rawCommentText contains the comment text without comment markers, empty lines and comment directives (like //nolint or //line) but still contains new lines for counting lines
 			rawCommentText := commentGroup.Text()
 			for comment := range strings.Lines(rawCommentText) {
-				if strings.HasPrefix(comment, "want `") {
-					// filter comments that are used for testing as these comments for analysistest
-					// would otherwise increase the logging density.
+				if isFilteredComment(comment) {
 					continue
 				}
 				commentLines += +1
@@ -266,4 +270,17 @@ func countCommentLines(node ast.Node) int {
 	})
 
 	return commentLines
+}
+
+// Method takes a comment and checks if it should be filtered
+// Currently, checks if the comment starts with given prefixes
+func isFilteredComment(comment string) bool {
+	isFiltered := false
+	for _, prefixFilter := range commentPrefixFilters {
+		if strings.HasPrefix(strings.ToLower(comment), strings.ToLower(prefixFilter)) {
+			// filter comments by comparing with given prefix, using both their lowercase version
+			isFiltered = true
+		}
+	}
+	return isFiltered
 }

--- a/function_rule.go
+++ b/function_rule.go
@@ -87,7 +87,7 @@ func (f FunctionRule[ResultType]) Analyse(node ast.Node, pass *analysis.Pass, fi
 
 	linesOfHeadlineComments := 0
 	if funcDecl.Doc != nil {
-		linesOfHeadlineComments = countCommentLines(funcDecl.Doc, pass.Fset)
+		linesOfHeadlineComments = countCommentLines(funcDecl.Doc)
 	}
 
 	commentSimilarity := StringSimilarity(funcDecl.Name.Name, funcDecl.Doc.Text())
@@ -152,7 +152,7 @@ func countInlineCommentsInFunction(f *ast.FuncDecl, commentsInFile []*ast.Commen
 	commentLines := 0
 	for _, comment := range commentsInFile {
 		if (comment.Pos() >= f.Pos()) && (comment.End() <= f.End()) {
-			commentLines += countCommentLines(comment, fset)
+			commentLines += countCommentLines(comment)
 		}
 	}
 	return commentLines
@@ -249,21 +249,21 @@ func countMeaningfulLines(source string) int {
 // countCommentLines counts the lines covered by comments in a given AST node.
 // This method takes into account that a command can span multiple lines using the /* */ syntax.
 // It can count the number of comments in both the headline and within a method's body.
-func countCommentLines(node ast.Node, fset *token.FileSet) int {
+func countCommentLines(node ast.Node) int {
 	commentLines := 0
 
 	// Traverse the node to find all comment groups
 	ast.Inspect(node, func(n ast.Node) bool {
 		if commentGroup, ok := n.(*ast.CommentGroup); ok {
-			for _, comment := range commentGroup.List {
-				if strings.HasPrefix(comment.Text, "// want `") {
+			// rawCommentText contains the comment text without comment markers, empty lines and comment directives (like //nolint or //line) but still contains new lines for counting lines
+			rawCommentText := commentGroup.Text()
+			for comment := range strings.Lines(rawCommentText) {
+				if strings.HasPrefix(comment, "want `") {
 					// filter comments that are used for testing as these comments for analysistest
 					// would otherwise increase the logging density.
 					continue
 				}
-				start := fset.Position(comment.Pos()).Line
-				end := fset.Position(comment.End()).Line
-				commentLines += end - start + 1
+				commentLines += +1
 			}
 		}
 		return true

--- a/function_rule.go
+++ b/function_rule.go
@@ -63,11 +63,7 @@ func (f FunctionRule[ResultType]) IsApplicable(node ast.Node, pass *analysis.Pas
 	// the result is cached and the analysis is not executed twice.
 	f.analysisResults = f.Analyse(node, pass, file)
 
-	if f.analysisResults.BodyLinesOfCode < f.Filters.MinLinesOfCode {
-		return false
-	}
-
-	return true
+	return f.analysisResults.BodyLinesOfCode >= f.Filters.MinLinesOfCode
 }
 
 func (f FunctionRule[ResultType]) Analyse(node ast.Node, pass *analysis.Pass, file *ast.File) *FunctionRuleResults {
@@ -82,7 +78,7 @@ func (f FunctionRule[ResultType]) Analyse(node ast.Node, pass *analysis.Pass, fi
 	}
 
 	linesInFunction := countLinesInFunction(funcDecl, pass.Fset)
-	linesOfCommentsInMethodBody := countInlineCommentsInFunction(funcDecl, file.Comments, pass.Fset)
+	linesOfCommentsInMethodBody := countInlineCommentsInFunction(funcDecl, file.Comments)
 	loggingStatements := countLoggingStatementsInFunction(funcDecl)
 
 	linesOfHeadlineComments := 0
@@ -148,7 +144,7 @@ func (r FunctionRuleResults) LoggingDensity() float64 {
 // These comments are not returned as part of the AST of a FuncDecl.
 // But all comments within a given file are available in the file's comments.
 // This function determines the number of lines of comment within a method body by checking the comments in the file.
-func countInlineCommentsInFunction(f *ast.FuncDecl, commentsInFile []*ast.CommentGroup, fset *token.FileSet) int {
+func countInlineCommentsInFunction(f *ast.FuncDecl, commentsInFile []*ast.CommentGroup) int {
 	commentLines := 0
 	for _, comment := range commentsInFile {
 		if (comment.Pos() >= f.Pos()) && (comment.End() <= f.End()) {

--- a/function_rule_test.go
+++ b/function_rule_test.go
@@ -31,5 +31,8 @@ func TestFunctionRule(t *testing.T) {
 	}}
 
 	analyzers, err := plugin.BuildAnalyzers()
+	if err != nil {
+		t.Fatalf("Failed to build analyzers: %s", err)
+	}
 	analysistest.Run(t, testdata, analyzers[0], "functions")
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/qaware/qaway-linter
 
-go 1.23
+go 1.24
 
 require (
 	github.com/golangci/plugin-module-register v0.1.1

--- a/interface_rule.go
+++ b/interface_rule.go
@@ -24,7 +24,7 @@ type InterfaceRule[ResultType InterfaceRuleResults] struct {
 	Params InterfaceRuleParameters `json:"params"`
 }
 
-func (i InterfaceRule[ResultType]) IsApplicable(node ast.Node, pass *analysis.Pass, _ *ast.File) bool {
+func (i InterfaceRule[ResultType]) IsApplicable(node ast.Node, _ *analysis.Pass, _ *ast.File) bool {
 	n, ok := node.(*ast.GenDecl)
 	if !ok {
 		return false
@@ -40,7 +40,7 @@ func (i InterfaceRule[ResultType]) IsApplicable(node ast.Node, pass *analysis.Pa
 	return true
 }
 
-func (i InterfaceRule[ResultType]) Analyse(node ast.Node, pass *analysis.Pass, _ *ast.File) *InterfaceRuleResults {
+func (i InterfaceRule[ResultType]) Analyse(node ast.Node, _ *analysis.Pass, _ *ast.File) *InterfaceRuleResults {
 	typespec, ok := node.(*ast.GenDecl)
 	if !ok {
 		return nil

--- a/interface_rule.go
+++ b/interface_rule.go
@@ -2,8 +2,8 @@ package qawaylinter
 
 import (
 	"go/ast"
-	"go/token"
 	"golang.org/x/tools/go/analysis"
+	"strings"
 )
 
 type InterfaceRuleParameters struct {
@@ -46,13 +46,13 @@ func (i InterfaceRule[ResultType]) Analyse(node ast.Node, pass *analysis.Pass, _
 		return nil
 	}
 
-	typeComments := countHeadlineComments(typespec.Doc, pass.Fset)
+	typeComments := countHeadlineComments(typespec.Doc)
 
 	var methodComments = make(map[string]int)
 	ast.Inspect(node, func(n ast.Node) bool {
 		if field, ok := n.(*ast.Field); ok {
 			if _, ok := field.Type.(*ast.FuncType); ok {
-				methodComments[field.Names[0].Name] = countHeadlineComments(field.Doc, pass.Fset)
+				methodComments[field.Names[0].Name] = countHeadlineComments(field.Doc)
 			}
 		}
 		return true
@@ -64,13 +64,13 @@ func (i InterfaceRule[ResultType]) Analyse(node ast.Node, pass *analysis.Pass, _
 	}
 }
 
-func countHeadlineComments(comments *ast.CommentGroup, fset *token.FileSet) int {
+func countHeadlineComments(comments *ast.CommentGroup) int {
 	if comments == nil {
 		return 0
 	}
-	start := fset.Position(comments.Pos()).Line
-	end := fset.Position(comments.End()).Line
-	return end - start + 1
+	// rawCommentText contains the comment text without comment markers, empty lines and comment directives (like //nolint or //line) but still contains new lines for counting lines
+	rawCommentText := comments.Text()
+	return strings.Count(rawCommentText, "\n")
 }
 
 func (i InterfaceRule[ResultType]) Apply(analysis *InterfaceRuleResults, node ast.Node, pass *analysis.Pass) {

--- a/interface_rule.go
+++ b/interface_rule.go
@@ -65,12 +65,20 @@ func (i InterfaceRule[ResultType]) Analyse(node ast.Node, _ *analysis.Pass, _ *a
 }
 
 func countHeadlineComments(comments *ast.CommentGroup) int {
+	commentLines := 0
 	if comments == nil {
-		return 0
+		return commentLines
 	}
 	// rawCommentText contains the comment text without comment markers, empty lines and comment directives (like //nolint or //line) but still contains new lines for counting lines
 	rawCommentText := comments.Text()
-	return strings.Count(rawCommentText, "\n")
+
+	for comment := range strings.Lines(rawCommentText) {
+		if isFilteredComment(comment) {
+			continue
+		}
+		commentLines++
+	}
+	return commentLines
 }
 
 func (i InterfaceRule[ResultType]) Apply(analysis *InterfaceRuleResults, node ast.Node, pass *analysis.Pass) {

--- a/interface_rule_test.go
+++ b/interface_rule_test.go
@@ -28,5 +28,8 @@ func TestInterfaceRule(t *testing.T) {
 		},
 	}}
 	analyzers, err := plugin.BuildAnalyzers()
+	if err != nil {
+		t.Fatalf("Failed to build analyzers: %s", err)
+	}
 	analysistest.Run(t, testdata, analyzers[0], "interfaces")
 }

--- a/struct_rule.go
+++ b/struct_rule.go
@@ -45,7 +45,7 @@ func (i StructRule[ResultType]) Analyse(node ast.Node, pass *analysis.Pass, _ *a
 		return nil
 	}
 
-	typeComments := countHeadlineComments(typespec.Doc, pass.Fset)
+	typeComments := countHeadlineComments(typespec.Doc)
 
 	var fieldComments = make(map[string]int)
 	ast.Inspect(node, func(n ast.Node) bool {
@@ -55,7 +55,7 @@ func (i StructRule[ResultType]) Analyse(node ast.Node, pass *analysis.Pass, _ *a
 					if len(field.Names) == 0 {
 						continue
 					}
-					fieldComments[field.Names[0].Name] = countHeadlineComments(field.Doc, pass.Fset)
+					fieldComments[field.Names[0].Name] = countHeadlineComments(field.Doc)
 				}
 			}
 		}

--- a/struct_rule.go
+++ b/struct_rule.go
@@ -23,7 +23,7 @@ type StructRule[ResultType StructRuleResults] struct {
 	Params StructRuleParameters `json:"params"`
 }
 
-func (i StructRule[ResultType]) IsApplicable(node ast.Node, pass *analysis.Pass, _ *ast.File) bool {
+func (i StructRule[ResultType]) IsApplicable(node ast.Node, _ *analysis.Pass, _ *ast.File) bool {
 	n, ok := node.(*ast.GenDecl)
 	if !ok {
 		return false
@@ -39,7 +39,7 @@ func (i StructRule[ResultType]) IsApplicable(node ast.Node, pass *analysis.Pass,
 	return true
 }
 
-func (i StructRule[ResultType]) Analyse(node ast.Node, pass *analysis.Pass, _ *ast.File) *StructRuleResults {
+func (i StructRule[ResultType]) Analyse(node ast.Node, _ *analysis.Pass, _ *ast.File) *StructRuleResults {
 	typespec, ok := node.(*ast.GenDecl)
 	if !ok {
 		return nil

--- a/struct_rule_test.go
+++ b/struct_rule_test.go
@@ -28,5 +28,8 @@ func TestStructRule(t *testing.T) {
 		}},
 	}
 	analyzers, err := plugin.BuildAnalyzers()
+	if err != nil {
+		t.Fatalf("Failed to build analyzers: %s", err)
+	}
 	analysistest.Run(t, testdata, analyzers[0], "struct")
 }

--- a/testdata/src/functions/functions.go
+++ b/testdata/src/functions/functions.go
@@ -197,3 +197,34 @@ func perfectMethod() bool {
 	log.Printf("Hello World")
 	return false
 }
+
+// Comment 1
+//
+//nolint:qawaylinter
+func methodWithEmptyComments() bool { // want `Method 'methodWithEmptyComments' has less than 10% comment density. Actual: 6%`
+	log.Printf("Hello World")
+
+	s := "abc"
+	s += "1"
+
+	if s == "" {
+		return true
+	}
+
+	s += "2"
+	if s == "" {
+		return true
+	}
+
+	s += "3"
+	if s == "" {
+		return true
+	}
+
+	s += "4"
+	if s == "" {
+		return true
+	}
+	log.Printf("Hello World")
+	return false
+}

--- a/testdata/src/functions/functions.go
+++ b/testdata/src/functions/functions.go
@@ -228,3 +228,8 @@ func methodWithEmptyComments() bool { // want `Method 'methodWithEmptyComments' 
 	log.Printf("Hello World")
 	return false
 }
+
+// TODO: should not count
+func filterOutTodoComments() bool { // want `Method 'filterOutTodoComments' is missing required headline comment` `Method 'filterOutTodoComments' has less than 10% comment density. Actual: 0%` `Method 'filterOutTodoComments' has less than 10% logging density. Actual: 0%`
+	return true
+}

--- a/testdata/src/interfaces/interface.go
+++ b/testdata/src/interfaces/interface.go
@@ -16,3 +16,11 @@ type TestWithComments interface {
 	// Comment
 	Method() bool
 }
+
+//
+//nolint:qawaylinter
+type TestWithEmptyCommentAndDirective interface { // want `Interface 'TestWithEmptyCommentAndDirective' is missing required headline comment` `Method 'Method' is missing required comment`
+	//
+	//nolint:qawaylinter
+	Method() bool
+}

--- a/testdata/src/interfaces/interface.go
+++ b/testdata/src/interfaces/interface.go
@@ -6,6 +6,11 @@ type TestWithoutComments interface { // want `Interface 'TestWithoutComments' is
 	Method() bool
 }
 
+// TODO: should not count
+type TestWithTodoComment interface { // want `Interface 'TestWithTodoComment' is missing required headline comment`
+
+}
+
 // This has a sample comment
 type TestWithHeadlineComments interface { // want `Method 'Method' is missing required comment`
 	Method() bool

--- a/testdata/src/struct/structs.go
+++ b/testdata/src/struct/structs.go
@@ -9,3 +9,8 @@ type TestWithoutComment struct { // want `Struct 'TestWithoutComment' is missing
 	// Comment
 	MethodWithComment string
 }
+
+//
+//nolint:qawaylinter
+type TestWithEmptyCommentAndDirective struct { // want `Struct 'TestWithEmptyCommentAndDirective' is missing required headline comment`
+}

--- a/testdata/src/struct/structs.go
+++ b/testdata/src/struct/structs.go
@@ -10,6 +10,11 @@ type TestWithoutComment struct { // want `Struct 'TestWithoutComment' is missing
 	MethodWithComment string
 }
 
+// TODO: should not count
+type TestWithTodoComment struct { // want `Struct 'TestWithTodoComment' is missing required headline comment`
+
+}
+
 //
 //nolint:qawaylinter
 type TestWithEmptyCommentAndDirective struct { // want `Struct 'TestWithEmptyCommentAndDirective' is missing required headline comment`


### PR DESCRIPTION
Fixes #7. 
Improved comment line counting by filtering empty lines and comment directives using commentGroups.Text() instead of iterating through the lines using commentGroups.List.
Needed to bump Go to 1.24 due to usage of strings.Lines() for counting lines in the comment text.

Additionally, I fixed some golangci-lint issues and code problems.